### PR TITLE
Correct misspelled port

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -30,7 +30,7 @@ Request.prototype.completeRequest = function(method, path, data, cb) {
       hostname: this.hostname,
       path: path,
       method: method.toUpperCase(),
-      post: 443,
+      port: 443,
       headers: {
         'User-Agent': 'node-bigcommerce/1.0.0'
       }


### PR DESCRIPTION
In configuring `options` hash for `https` request, `port` is misspelled as `post`. 