### PR TITLE
Prevent es6-polyfill from messing with promises

### DIFF
--- a/lib/bigcommerce.js
+++ b/lib/bigcommerce.js
@@ -22,8 +22,6 @@ var logger = require('./logger'),
   crypto = require('crypto'),
   Request = require('./request');
 
-require('es6-promise').polyfill();
-
 var BigCommerce = function(cfg) {
   // The config is required to access the API
   if (!cfg) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,6 +1,9 @@
 'use strict';
 
-require('es6-promise').polyfill();
+// Polyfill if the global promise does not exist.
+if (!global.Promise) {
+  require('es6-promise').polyfill();
+}
 
 module.exports = {
   /**

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "jshint": "^2.9.1",
     "mocha": "^2.4.5",
     "nock": "^7.0.2",
+    "require-reload": "^0.2.2",
     "sinon": "^1.17.3"
   },
   "dependencies": {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var helpers = require('../lib/helpers'),
+var reload = require('require-reload')(require),
+  helpers = require('../lib/helpers'),
   logger = require('../lib/logger'),
   should = require('chai').should(),
   sinon = require('sinon');
@@ -26,6 +27,21 @@ describe('Helpers', function() {
         .catch(function(err) {
           err.message.should.equal('oh no');
           done();
+        });
+    });
+
+    it('should work when there is no global promise', function() {
+      var oldPromise = global.Promise;
+      global.Promise = undefined;
+
+      helpers = reload('../lib/helpers');
+
+      var deferred = helpers.defer();
+      deferred.resolve(123);
+      return deferred.promise
+        .then(function(result) {
+          result.should.equal(123);
+          global.Promise = oldPromise;
         });
     });
   });


### PR DESCRIPTION
This commit prevents es6-polyfill from running when a global Promise
object already exists.